### PR TITLE
Added updating test result when test result already exists in nlims

### DIFF
--- a/lib/test_service.rb
+++ b/lib/test_service.rb
@@ -110,6 +110,9 @@ module TestService
 								device_name: '',						
 								time_entered: result_date
 							)
+						else
+							test_result_ = TestResult.where(test_id: test_id, measure_id: measure.id).first
+							test_result_.update(result: result_value, time_entered: result_date)
 						end
 						test_results_measures[measure_name] = { 'result_value': result_value }						
 					end	


### PR DESCRIPTION
Added test result updating capability whenever emr or any other system updates a result that has already synced with Local NLIMS. The updating of Local NLIMS result also updates couchdb for replication with CHSU NLIMS