### PR TITLE
Fix rh4 integration issue of missing pickup from hub information

### DIFF
--- a/app/controllers/api/v1/order_controller.rb
+++ b/app/controllers/api/v1/order_controller.rb
@@ -109,7 +109,7 @@ class API::V1::OrderController < ApplicationController
 	def check_if_dispatched
 	
 		if !params[:tracking_number].blank?
-			res = OrderService.check_if_dispatched(params[:tracking_number])
+			res = OrderService.check_if_dispatched(params[:tracking_number], params[:dispatcher_type_id])
 			if res == false
 				response = {
 								status: 200,

--- a/app/controllers/api/v1/order_controller.rb
+++ b/app/controllers/api/v1/order_controller.rb
@@ -252,7 +252,7 @@ class API::V1::OrderController < ApplicationController
 							}
 						end
 						
-					elsif case_type == "delivery"
+					elsif case_type == "r4h_delivery"
 						tracking_numbers = params[:properties]["tracking_numbers"]
 						date_dispatched = params[:properties]["date_of_delivery"]
 						time_of_delivery = params[:properties]["time_of_delivery"]

--- a/app/controllers/api/v1/order_controller.rb
+++ b/app/controllers/api/v1/order_controller.rb
@@ -283,7 +283,9 @@ class API::V1::OrderController < ApplicationController
 												}
 										}
 									else
-								
+										if dispatcher_type_id.id == 1
+											OrderService.record_r4h_pickup_from_hub(params[:properties]["pickup_info"], dispatcher)
+										end
 										response = {
 													status: 200,
 													error: false,

--- a/db/seed_dispatcher_types.rb
+++ b/db/seed_dispatcher_types.rb
@@ -1,4 +1,4 @@
-dispatcher_types = ['delivering_samples_to_molecular_lab','delivering_samples_to_district_hub','delivering_results_to_facility','sample_dispatched_from_facility']
+dispatcher_types = ['delivering_samples_to_molecular_lab','delivering_samples_to_district_hub','delivering_results_to_facility','sample_dispatched_from_facility', 'pickup_sample_from_hub']
 
 
 puts 'loading dispatcher types--------------'

--- a/lib/order_service.rb
+++ b/lib/order_service.rb
@@ -635,12 +635,15 @@ module  OrderService
                   date_picked_up = info['date_picked_from_hub']
                   time_picked_from_hub = info['time_picked_from_hub']
                   datetime_picked_from_hub = date_picked_up + " "+ time_picked_from_hub
-                  SpecimenDispatch.create(
-                        tracking_number: info['tracking_number'],
-                        dispatcher: dispatcher,
-                        date_dispatched: datetime_picked_from_hub,
-                        dispatcher_type_id: 5
-                  )
+                  dispatched = SpecimenDispatch.where(tracking_number: info['tracking_number'], dispatcher_type_id: 5).first
+                  if dispatched.nil?
+                        SpecimenDispatch.create(
+                              tracking_number: info['tracking_number'],
+                              dispatcher: dispatcher,
+                              date_dispatched: datetime_picked_from_hub,
+                              dispatcher_type_id: 5
+                        )
+                  end
             end
       end
 

--- a/lib/order_service.rb
+++ b/lib/order_service.rb
@@ -1,4 +1,4 @@
-
+require 'json'
 module  OrderService
 
       def self.create_order(params,tracking_number)
@@ -630,7 +630,7 @@ module  OrderService
       end
 
       def self.record_r4h_pickup_from_hub(pickup_info, dispatcher)
-            pickup_info.each do |info|
+            JSON.parse(pickup_info).each do |info|
                   date_picked_up = info['date_picked_from_hub']
                   time_picked_from_hub = info['time_picked_from_hub']
                   datetime_picked_from_hub = date_picked_up + " "+ time_picked_from_hub

--- a/lib/order_service.rb
+++ b/lib/order_service.rb
@@ -630,6 +630,7 @@ module  OrderService
       end
 
       def self.record_r4h_pickup_from_hub(pickup_info, dispatcher)
+            pickup_info = pickup_info.gsub('[\\{','[{').gsub('\\}]', '}]').gsub('tracking_number', '"tracking_number"').gsub('time_picked_from_hub', '"time_picked_from_hub"').gsub('date_picked_from_hub', '"date_picked_from_hub"').gsub(/\\/, '')
             JSON.parse(pickup_info).each do |info|
                   date_picked_up = info['date_picked_from_hub']
                   time_picked_from_hub = info['time_picked_from_hub']

--- a/lib/order_service.rb
+++ b/lib/order_service.rb
@@ -629,6 +629,20 @@ module  OrderService
             return true
       end
 
+      def self.record_r4h_pickup_from_hub(pickup_info, dispatcher)
+            pickup_info.each do |info|
+                  date_picked_up = info['date_picked_from_hub']
+                  time_picked_from_hub = info['time_picked_from_hub']
+                  datetime_picked_from_hub = date_picked_up + " "+ time_picked_from_hub
+                  SpecimenDispatch.create(
+                        tracking_number: info['tracking_number'],
+                        dispatcher: dispatcher,
+                        date_dispatched: datetime_picked_from_hub,
+                        dispatcher_type_id: 5
+                  )
+            end
+      end
+
       def self.check_if_dispatched(tracking_number,dispatcher_type)
             rs = SpecimenDispatch.find_by_sql("SELECT * FROM specimen_dispatches WHERE tracking_number='#{tracking_number}' AND dispatcher_type_id='#{dispatcher_type}'")
             if rs.length > 0


### PR DESCRIPTION
This PR fixes the issue of missing  pickup from hub information when r4h personel picks sample from hub to molecular lab.  Ha been tested on testbench with the help of r4h developer.