### PR TITLE
Added missing recipient types meta data

### DIFF
--- a/db/seed_test_results_recepient_types.rb
+++ b/db/seed_test_results_recepient_types.rb
@@ -1,18 +1,15 @@
-recepient_types = ['test_results_delivered_to_site_manually','test_results_delivered_to_site_electronically']
-
-
+recepient_types = %w[test_results_delivered_to_site_manually test_results_delivered_to_site_electronically
+                     test_results_delivered_to_site_electronically_at_local_nlims_level]
 puts 'loading recepient types--------------'
-
 recepient_types.each do |type|
-   # tca = TestCategory.create(name: ca, description: '') 
-    chk = TestResultRecepientType.find_by(name: type)  
-    if !chk.blank?
-        puts "#{type} already seeded"
-    else
-        tca = TestResultRecepientType.new
-        tca.name = type
-        tca.description = ""
-        tca.save()
-        puts "#{type} seeded successfuly"
-    end
+  chk = TestResultRecepientType.find_by(name: type)
+  if !chk.blank?
+    puts "#{type} already seeded"
+  else
+    tca = TestResultRecepientType.new
+    tca.name = type
+    tca.description = ''
+    tca.save
+    puts "#{type} seeded successfuly"
+  end
 end


### PR DESCRIPTION
This PR add test_results_delivered_to_site_electronically_at_local_nlims_level recipient type metadata that was missing but is used in the EID/VL integration. hence fixing the issue of failing to acknowleged result receipt at local nlims by chsu nlims