### PR TITLE
Add couch_id parameter to order query

### DIFF
--- a/app/controllers/api/v2/order_controller.rb
+++ b/app/controllers/api/v2/order_controller.rb
@@ -30,7 +30,6 @@ class API::V2::OrderController < ApplicationController
     elsif !params['who_order_test_last_name']
       msg = 'last name for person ordering not provided'
     else
-      order_availability = false
       if params['tracking_number']
         tracking_number = params['tracking_number']
         order_availability = OrderService.check_order(tracking_number)
@@ -40,7 +39,7 @@ class API::V2::OrderController < ApplicationController
             error: false,
             message: 'order already available',
             data: {
-              tracking_number: tracking_number
+              tracking_number:
             }
           }
           render plain: response.to_json and return
@@ -76,7 +75,11 @@ class API::V2::OrderController < ApplicationController
 
   def query_order_by_tracking_number
     if params[:tracking_number]
-      res = OrderService.query_order_by_tracking_number_v2(params[:tracking_number], params[:test_name])
+      res = OrderService.query_order_by_tracking_number_v2(
+        params[:tracking_number],
+        params[:test_name],
+        params[:couch_id]
+      )
       response = if res == false
                    {
                      status: 200,

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -116,8 +116,9 @@ module OrderService
     end
   end
 
-  def self.query_order_by_tracking_number_v2(tracking_number, test_name)
+  def self.query_order_by_tracking_number_v2(tracking_number, test_name, couch_id)
     test_name = NameMapping.actual_name_of(test_name)
+    couch_id_condition = couch_id.blank? ? '' : "AND specimen.couch_id='#{couch_id}'"
     res = Speciman.find_by_sql("SELECT specimen_types.name AS sample_type, specimen_statuses.name AS specimen_status,
                         wards.name AS order_location, specimen.date_created AS date_created, specimen.priority AS priority,
                         specimen.drawn_by_id AS drawer_id, specimen.drawn_by_name AS drawer_name,
@@ -133,7 +134,7 @@ module OrderService
                         INNER JOIN tests ON tests.specimen_id = specimen.id
                         INNER JOIN patients ON patients.id = tests.patient_id
                         LEFT JOIN wards ON specimen.ward_id = wards.id
-                        WHERE specimen.tracking_number ='#{tracking_number}'")
+                        WHERE specimen.tracking_number ='#{tracking_number}' #{couch_id_condition}")
     tsts = {}
     result_status = false
     result_measures = {}


### PR DESCRIPTION
Introduce a `couch_id` parameter to the order query to enhance filtering capabilities. Remove an unused variable to clean up the code.