### PR TITLE
Refactor specimen and test status updates for clarity and maintainability

### DIFF
--- a/app/services/nlims_sync_utils_service.rb
+++ b/app/services/nlims_sync_utils_service.rb
@@ -25,7 +25,8 @@ class NlimsSyncUtilsService
     {
       tracking_number: order&.tracking_number,
       status: status,
-      who_updated: who_updated(order_status_trail)
+      who_updated: who_updated(order_status_trail),
+      time_updated: order_status_trail&.time_updated
     }
   end
 
@@ -131,7 +132,8 @@ class NlimsSyncUtilsService
       test_status: test_status,
       test_name: TestType.find_by(id: test_record&.test_type_id)&.name,
       result_date: '',
-      who_updated: who_updated(test_status_trail)
+      who_updated: who_updated(test_status_trail),
+      time_updated: test_status_trail&.time_updated
     }
     return payload if results.empty?
 

--- a/app/services/specimen_status_updater_service.rb
+++ b/app/services/specimen_status_updater_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# This service updates the status of a specimen while ensuring valid state transitions.
+# It is used in various parts of the application to maintain specimen status integrity.
+class SpecimenStatusUpdaterService
+  ALLOWED_TRANSITIONS = {
+    'specimen_not_collected' => %w[specimen_collected specimen_rejected specimen_accepted sample_accepted_at_hub
+                                   sample_rejected_at_hub sample_accepted_at_ml sample_rejected_at_ml],
+    'specimen_collected' => %w[specimen_accepted specimen_rejected sample_accepted_at_hub sample_rejected_at_hub
+                               sample_accepted_at_ml sample_rejected_at_ml],
+    'sample_accepted_at_hub' => %w[specimen_accepted specimen_rejected sample_accepted_at_ml sample_rejected_at_ml],
+    'sample_accepted_at_ml' => %w[specimen_accepted specimen_rejected]
+  }.freeze
+
+  def initialize(order, specimen_status)
+    @order = order
+    @specimen_status = specimen_status
+    @current_status = SpecimenStatus.find_by(id: @order&.specimen_status_id)
+  end
+
+  def update_status
+    return false unless valid_input? && valid_transition?
+
+    @order.update!(specimen_status_id: @specimen_status.id)
+  end
+
+  def self.call(order, specimen_status)
+    new(order, specimen_status).update_status
+  end
+
+  private
+
+  def valid_input?
+    @order.present? && @specimen_status.present?
+  end
+
+  def valid_transition?
+    return false if ALLOWED_TRANSITIONS[@current_status&.name].blank?
+
+    ALLOWED_TRANSITIONS[@current_status&.name].include?(@specimen_status.name) || @current_status == @specimen_status
+  end
+end

--- a/app/services/test_service.rb
+++ b/app/services/test_service.rb
@@ -39,7 +39,7 @@ module TestService
         )
       end
       TestStatusUpdaterService.call(test_id, test_status)
-      if test_status.id == 5 && params[:results]
+      if test_status.id == TestStatus.find_by(name: 'verified')&.id && params[:results]
         result_date = params[:result_date].blank? ? Time.now.strftime('%Y%m%d%H%M%S') : params[:result_date]
         state, error_message = validate_time_updated(result_date, sql_order)
         unless state

--- a/app/services/test_service.rb
+++ b/app/services/test_service.rb
@@ -38,7 +38,7 @@ module TestService
           who_updated_phone_number: ''
         )
       end
-      update_test_status(test_id, test_status)
+      TestStatusUpdaterService.call(test_id, test_status)
       if test_status.id == 5 && params[:results]
         result_date = params[:result_date].blank? ? Time.now.strftime('%Y%m%d%H%M%S') : params[:result_date]
         state, error_message = validate_time_updated(result_date, sql_order)
@@ -100,33 +100,6 @@ module TestService
     end
     # Proceed - return success or continue with rest of logic
     [true, nil]
-  end
-
-  def self.update_test_status(test_id, new_status)
-    allowed_transitions = {
-      9 => [2, 3, 4, 5],
-      2 => [3, 4, 5],
-      3 => [4, 5],
-      4 => [5],
-      12 => [4, 5],
-      nil => [10, 11]
-    }.freeze
-    test = Test.find_by(id: test_id)
-
-    return false unless test && new_status
-
-    current_status = test.test_status_id
-    new_status_id = new_status.id
-
-    # Check if transition is allowed
-    if allowed_transitions[current_status]&.include?(new_status_id) ||
-       allowed_transitions[nil]&.include?(new_status_id)
-      test.update!(test_status_id: new_status_id)
-    elsif new_status_id == 12
-      test.update!(test_status_id: new_status_id)
-    else
-      false
-    end
   end
 
   def self.result_sync_tracker(tracking_number, test_id)

--- a/app/services/test_status_updater_service.rb
+++ b/app/services/test_status_updater_service.rb
@@ -16,7 +16,8 @@ class TestStatusUpdaterService
                                   test-rejected],
     'pending' => %w[started completed verified rejected test_on_repeat test-rejected voided],
     'started' => %w[completed verified rejected test_on_repeat test-rejected voided],
-    'completed' => %w[verified rejected test_on_repeat test-rejected],
+    'completed' => %w[verified test_on_repeat],
+    'verified' => %w[test_on_repeat],
     'test_on_repeat' => %w[completed verified]
   }.freeze
 

--- a/app/services/test_status_updater_service.rb
+++ b/app/services/test_status_updater_service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# This service updates the status of a test while ensuring valid state transitions.
+# It is used in various parts of the application to maintain test status integrity.
+class TestStatusUpdaterService
+  ALLOWED_TRANSITIONS = {
+    'drawn' => %w[pending started completed verified rejected test_on_repeat test-rejected voided
+                  sample_accepted_at_hub sample_rejected_at_hub sample_intransit_to_ml sample_accepted_at_ml
+                  sample_rejected_at_ml],
+    'sample_accepted_at_hub' => %w[pending started completed verified rejected test_on_repeat voided
+                                   test-rejected sample_intransit_to_ml sample_accepted_at_ml
+                                   sample_rejected_at_ml],
+    'sample_intransit_to_ml' => %w[pending started completed verified rejected test_on_repeat voided
+                                   test-rejected sample_accepted_at_ml sample_rejected_at_ml],
+    'sample_accepted_at_ml' => %w[pending started completed verified rejected test_on_repeat voided
+                                  test-rejected],
+    'pending' => %w[started completed verified rejected test_on_repeat test-rejected voided],
+    'started' => %w[completed verified rejected test_on_repeat test-rejected voided],
+    'completed' => %w[verified rejected test_on_repeat test-rejected],
+    'test_on_repeat' => %w[completed verified]
+  }.freeze
+
+  def initialize(test_id, test_status)
+    @test = Test.find_by(id: test_id)
+    @new_status = test_status
+    @current_status = TestStatus.find_by(id: @test&.test_status_id)
+  end
+
+  def update_status
+    return false unless valid_input? && valid_transition?
+
+    @test.update!(test_status_id: @new_status.id)
+  end
+
+  def self.call(test_id, test_status)
+    new(test_id, test_status).update_status
+  end
+
+  private
+
+  def valid_input?
+    @test.present? && @new_status.present?
+  end
+
+  def valid_transition?
+    return false if ALLOWED_TRANSITIONS[@current_status&.name].blank?
+
+    ALLOWED_TRANSITIONS[@current_status&.name].include?(@new_status.name) || @current_status == @new_status
+  end
+end

--- a/db/seed_additional_test_statuses.rb
+++ b/db/seed_additional_test_statuses.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-test_statuses = %w[test_on_repeat]
+test_statuses = %w[pending started completed verified rejected test_on_repeat test-rejected voided
+                   sample_accepted_at_hub sample_rejected_at_hub sample_intransit_to_ml sample_accepted_at_ml
+                   sample_rejected_at_ml drawn]
 
 test_statuses.each do |status|
   puts "Seeding additional test status: #{status}"
@@ -9,4 +11,15 @@ test_statuses.each do |status|
   next if status.present?
 
   TestStatus.find_or_create_by!(name: status)
+end
+
+specimen_statuses = %w[specimen_collected specimen_rejected specimen_accepted sample_accepted_at_hub
+                       sample_rejected_at_hub sample_accepted_at_ml sample_rejected_at_ml]
+specimen_statuses.each do |status|
+  puts "Seeding additional specimen status: #{status}"
+  status = SpecimenStatus.find_by(name: status)
+  puts "#{status.name} already exists, skipping..." if status.present?
+  next if status.present?
+
+  SpecimenStatus.find_or_create_by!(name: status)
 end


### PR DESCRIPTION
This PR introduces a new service objects responsible for handling and validating test status transitions in a centralized, maintainable, and readable way.

Previously, the logic for updating test statuses was embedded directly in models or controllers, using hardcoded numeric IDs. This made it difficult to understand, test, and maintain.

The new service replaces that logic with a clean, reusable class that:

Uses human-readable status names in ALLOWED_TRANSITIONS

Still performs updates using status IDs internally

Ensures that only valid transitions occur according to defined rules

It also update test status condition to utilize dynamic lookup for 'verified' status.