### PR TITLE
Add last app check-in date to integration status report and index migration

### DIFF
--- a/app/services/integration_status_service.rb
+++ b/app/services/integration_status_service.rb
@@ -102,7 +102,8 @@ class IntegrationStatusService
         status_last_updated: Time.now.strftime('%d/%b/%Y %H:%M'),
         last_sync_date_gt_24hr: last_sync_date_gt_24hr?(last_sync_date),
         last_sync_date: last_sync_date.present? ? last_sync_date.strftime('%d/%b/%Y %H:%M') : 'Has Never Synced with NLIMS',
-        order_summary: order_summary
+        order_summary: order_summary,
+        last_app_check_in_date: AppCheckIn.where(site_id: site[:id]).order('check_in_time DESC').first&.check_in_time
       }
     rescue StandardError => e
       puts "[Error] #{e.class}: #{e.message}"

--- a/db/migrate/20251008080755_add_index_to_app_check_in.rb
+++ b/db/migrate/20251008080755_add_index_to_app_check_in.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Migration to add index to app_check_ins table
+class AddIndexToAppCheckIn < ActiveRecord::Migration[7.1]
+  def change
+    add_index :app_check_ins, :site_id if !index_exists?(:app_check_ins, :site_id)
+    add_index :app_check_ins, :check_in_time if !index_exists?(:app_check_ins, :check_in_time)
+    add_index :app_check_ins, :name if !index_exists?(:app_check_ins, :name)
+  end
+end


### PR DESCRIPTION
Include the last app check-in date in the integration status report and create a migration to add indexes to the app_check_ins table for improved query performance.